### PR TITLE
feat: WeasyPrint PDF sidecar + /api/weasyprint proxy route

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,0 +1,77 @@
+name: Build & push Docker images
+
+# Builds and pushes both images with one tagging scheme:
+#   push develop      -> :develop
+#   push main         -> :latest
+#   release published -> :stable, :<major>, :<major>.<minor>, :<major>.<minor>.<patch>
+#                        (semver taken from the release tag, e.g. v1.4.2)
+#
+# Images: door43-preview-app and door43-preview-weasyprint, on the same registry
+# and the same tags. Replaces Docker Hub's (retiring) autobuild service.
+on:
+  push:
+    branches: [develop, main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+env:
+  # Registry to push to. The login uses the DOCKER_BUILD_USERNAME / DOCKER_BUILD_TOKEN
+  # repo secrets. Change REGISTRY if these images should live elsewhere.
+  REGISTRY: hub.door43.org
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: door43-preview-app
+            context: .
+            file: ./Dockerfile
+          - name: door43-preview-weasyprint
+            context: ./weasyprint-service
+            file: ./weasyprint-service/Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_BUILD_USERNAME }}
+          password: ${{ secrets.DOCKER_BUILD_TOKEN }}
+
+      - name: Compute tags and labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ matrix.name }}
+          # Branch tags are gated by ref; the semver tags only apply on a release.
+          tags: |
+            type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=stable,enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and push ${{ matrix.name }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          push: true
+          # EC2 prod is amd64; add linux/arm64 (with QEMU) here if needed.
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,14 +11,37 @@ services:
       - CACHE_DIR=/app/cached-files
       - DCS_READ_ONLY_TOKEN=${DCS_READ_ONLY_TOKEN}
       - PREVIEW_VERIFICATION_KEY=${PREVIEW_VERIFICATION_KEY}
+      # Internal weasyprint-service (HTML -> PDF), reachable on the compose network.
+      - WEASYPRINT_SERVICE_URL=http://weasyprint:8080
     volumes:
       - ./cached-files:/app/cached-files
     env_file:
       - .env
     restart: unless-stopped
+    depends_on:
+      - weasyprint
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"]
       interval: 30s
       timeout: 3s
       retries: 3
       start_period: 40s
+
+  # HTML -> PDF engine (WeasyPrint). Internal only — `expose`, not `ports` — so it
+  # is reachable by the app on the compose network but not published publicly; the
+  # public surface is the app's /api/weasyprint route (with its CORS).
+  weasyprint:
+    build:
+      context: ./weasyprint-service
+      dockerfile: Dockerfile
+    expose:
+      - "8080"
+    environment:
+      - PORT=8080
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8080/health').status==200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s

--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,7 @@ import saveHtmltoCacheHandler from './routes/save-html-to-cache.js';
 import getCachedHtmlHandler from './routes/get-cached-html.js';
 import serveCachedPage from './routes/serve-cached-page.js';
 import configRoute from './routes/config.js';
+import weasyprintHandler from './routes/weasyprint.js';
 
 dotenv.config();
 
@@ -42,6 +43,13 @@ app.get('/api/get-cached-html', getCachedHtmlHandler);
 
 // Direct cached page serving (fast path)
 app.get('/api/cached-page', serveCachedPage);
+
+// HTML -> PDF via the internal weasyprint-service (text/html in, application/pdf out)
+app.post(
+  '/api/weasyprint',
+  express.text({ type: ['text/html', 'text/plain'], limit: '50mb' }),
+  weasyprintHandler
+);
 
 // Serve static files from dist folder (production)
 if (process.env.NODE_ENV === 'production') {

--- a/server/routes/weasyprint.js
+++ b/server/routes/weasyprint.js
@@ -1,0 +1,43 @@
+// POST /api/weasyprint — proxy a complete print HTML document to the internal
+// weasyprint-service and stream back the PDF.
+//
+// The WeasyPrint engine (Python) runs in its own container; this Express route is
+// the public, CORS-enabled surface (e.g. preview.door43.org/api/weasyprint) used
+// both by this app and by the door43-preview-renderers styleguide (as its
+// `pdfServiceUrl`). Contract: POST text/html -> application/pdf.
+
+const SERVICE_URL = process.env.WEASYPRINT_SERVICE_URL || 'http://localhost:8080';
+
+export default async function weasyprint(req, res) {
+  const html = typeof req.body === 'string' ? req.body : '';
+  if (!html.trim()) {
+    return res
+      .status(400)
+      .json({ error: 'POST a complete HTML document (Content-Type: text/html).' });
+  }
+
+  try {
+    const upstream = await fetch(SERVICE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/html' },
+      body: html,
+    });
+
+    if (!upstream.ok) {
+      const detail = await upstream.text().catch(() => upstream.statusText);
+      return res
+        .status(502)
+        .json({ error: `weasyprint service error (${upstream.status}): ${String(detail).slice(0, 500)}` });
+    }
+
+    const pdf = Buffer.from(await upstream.arrayBuffer());
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', 'inline; filename="preview.pdf"');
+    res.setHeader('Content-Length', pdf.length);
+    res.end(pdf);
+  } catch (e) {
+    res
+      .status(502)
+      .json({ error: `weasyprint service unreachable at ${SERVICE_URL}: ${e.message}` });
+  }
+}

--- a/weasyprint-service/.gitignore
+++ b/weasyprint-service/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/weasyprint-service/Dockerfile
+++ b/weasyprint-service/Dockerfile
@@ -18,7 +18,7 @@ USER root
 
 # Native deps for WeasyPrint + a base font. cairo / glib / harfbuzz come in as
 # transitive deps of pango / gdk-pixbuf.
-RUN apk add --no-cache pango gdk-pixbuf fontconfig font-dejavu \
+RUN apk add --no-cache pango gdk-pixbuf fontconfig ttf-dejavu \
  && python -m venv /venv
 
 WORKDIR /app

--- a/weasyprint-service/Dockerfile
+++ b/weasyprint-service/Dockerfile
@@ -1,0 +1,36 @@
+# weasyprint-service — HTML -> PDF, on a hardened Chainguard (Wolfi) Python base.
+#
+# WeasyPrint is a Python library with a native stack (Pango / cairo / gdk-pixbuf /
+# harfbuzz / fontconfig). Wolfi is glibc-based, so it runs the same as on Debian.
+# We use the `:latest-dev` variant because it ships `apk` + a shell to install
+# that native stack — it is still a low-CVE Chainguard image, not a generic distro.
+#
+# ⚠️ Authored without registry access — confirm with a real `docker build`:
+#   - exact Wolfi apk package names (`apk search pango cairo gdk-pixbuf …` in a
+#     `cgr.dev/chainguard/wolfi-base:latest-dev` shell);
+#   - that the `nonroot` user exists in this image.
+# A smaller distroless multi-stage build is possible, but the minimal runtime
+# stage must also carry WeasyPrint's native .so libs (not just the Python venv) —
+# see README.md.
+FROM cgr.dev/chainguard/python:latest-dev
+
+USER root
+
+# Native deps for WeasyPrint + a base font. cairo / glib / harfbuzz come in as
+# transitive deps of pango / gdk-pixbuf.
+RUN apk add --no-cache pango gdk-pixbuf fontconfig font-dejavu \
+ && python -m venv /venv
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN /venv/bin/pip install --no-cache-dir -r requirements.txt
+COPY server.py ./
+
+ENV PATH="/venv/bin:$PATH" \
+    PORT=8080
+EXPOSE 8080
+
+# Drop privileges for the runtime.
+USER nonroot
+
+CMD ["python", "server.py"]

--- a/weasyprint-service/README.md
+++ b/weasyprint-service/README.md
@@ -1,0 +1,84 @@
+# weasyprint-service
+
+A tiny, stateless **HTML → PDF** service backed by [WeasyPrint](https://weasyprint.org/),
+running on a hardened Chainguard (Wolfi) Python base. It lets the preview app —
+and the door43-preview-renderers styleguide — produce real WeasyPrint PDFs without
+installing the Python/native stack into the app's (Chainguard Node) image.
+
+It renders with WeasyPrint's **Python API** in-process (no subprocess), and is meant
+to sit on a **private network** behind the app's `/api/weasyprint` proxy route, so it
+does no CORS itself — the Express app owns the public surface and its CORS.
+
+## API
+
+| Method | Path | Body | Response |
+|---|---|---|---|
+| `POST` | `/` | `Content-Type: text/html` — a complete HTML document | `200 application/pdf` |
+| `GET` | `/health` | — | `200 "ok"` |
+
+Env: `PORT` (8080), `MAX_BODY_BYTES` (32 MiB).
+
+## How it fits together
+
+```
+browser / styleguide / app  ──POST /api/weasyprint (text/html)──►  Express (door43-preview-app)
+                                                                      │  proxies to
+                                                                      ▼
+                                                          weasyprint-service  ──►  PDF
+                                                          (internal, this dir)
+```
+
+- `server/routes/weasyprint.js` proxies `POST /api/weasyprint` to this service at
+  `WEASYPRINT_SERVICE_URL` (default `http://localhost:8080`; `http://weasyprint:8080`
+  under docker-compose).
+- The styleguide's Render PDF demo can point its **PDF service URL** at
+  `https://preview.door43.org/api/weasyprint`; the library/CLI can pass it as
+  `pdfServiceUrl`.
+
+## Run with docker-compose (recommended)
+
+`docker-compose.yml` already defines this as an internal `weasyprint` service and
+wires `WEASYPRINT_SERVICE_URL` into the app:
+
+```bash
+docker compose up -d --build
+```
+
+## Build / run standalone
+
+```bash
+docker build -t weasyprint-service weasyprint-service
+docker run --rm -p 8080:8080 weasyprint-service
+
+printf '<!doctype html><h1>Hello PDF</h1>' \
+  | curl -s -X POST --data-binary @- -H 'Content-Type: text/html' \
+    http://localhost:8080 -o out.pdf && file out.pdf
+```
+
+## ⚠️ Build verification (authored without registry access)
+
+Confirm these against a real `docker build`:
+
+- **Wolfi package names** — `pango gdk-pixbuf fontconfig font-dejavu` are the
+  likely names; verify with `apk search …` in a `cgr.dev/chainguard/wolfi-base:latest-dev`
+  shell and add any missing native dep WeasyPrint reports at runtime.
+- **`nonroot` user** exists in `cgr.dev/chainguard/python:latest-dev` (or switch to
+  the numeric `USER 65532`).
+
+The server itself is verified: running `server.py` under the WeasyPrint interpreter
+renders a valid PDF from a `POST`.
+
+### Smaller (distroless) image — optional follow-up
+
+The current Dockerfile is single-stage on the `-dev` image (still low-CVE, but it
+carries `apk`/shell). A distroless multi-stage build (build on `…:latest-dev`,
+run on `cgr.dev/chainguard/python:latest`) is smaller, but the **runtime** stage
+must also carry WeasyPrint's native `.so` libs (Pango/cairo/…), not just the Python
+venv — copy them from the build stage and verify with `ldd`.
+
+## Deploy
+
+Any container host: `docker compose` on the EC2 box (behind the existing nginx),
+or build/push the image and run it as a second service/task. If exposed directly
+(not via the app proxy), add CORS for the calling origin and keep it behind
+auth / network limits — it renders arbitrary posted HTML.

--- a/weasyprint-service/requirements.txt
+++ b/weasyprint-service/requirements.txt
@@ -1,0 +1,2 @@
+# Pinned to the version verified locally; bump as needed (and re-test).
+weasyprint==68.1

--- a/weasyprint-service/server.py
+++ b/weasyprint-service/server.py
@@ -1,0 +1,65 @@
+"""weasyprint-service — a tiny "HTML -> PDF" HTTP service.
+
+Contract (same as the door43-preview-renderers `pdfServiceUrl`):
+    POST /          Content-Type: text/html, body = a complete HTML document
+                    -> 200 application/pdf (the rendered PDF bytes)
+    GET  /health    -> 200 "ok"
+
+It renders with WeasyPrint's Python API (no subprocess). It is meant to sit on a
+private network behind the door43-preview-app `/api/weasyprint` proxy route, so it
+does not do CORS itself — the Express app owns the public surface and its CORS.
+
+Env: PORT (8080), MAX_BODY_BYTES (32 MiB).
+"""
+
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from weasyprint import HTML
+
+PORT = int(os.environ.get("PORT", "8080"))
+MAX_BODY_BYTES = int(os.environ.get("MAX_BODY_BYTES", str(32 * 1024 * 1024)))
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send(self, code, body, content_type="text/plain; charset=utf-8"):
+        data = body if isinstance(body, (bytes, bytearray)) else str(body).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(data)
+
+    def do_GET(self):
+        if self.path in ("/health", "/"):
+            self._send(200, "ok")
+        else:
+            self._send(404, "not found")
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        if length <= 0:
+            return self._send(400, "empty body - POST a complete HTML document")
+        if length > MAX_BODY_BYTES:
+            return self._send(413, "payload too large")
+
+        html = self.rfile.read(length).decode("utf-8")
+        try:
+            pdf = HTML(string=html).write_pdf()
+        except Exception as exc:  # noqa: BLE001 - report any render failure to the caller
+            return self._send(500, f"weasyprint failed: {exc}")
+
+        self._send(200, pdf, "application/pdf")
+
+    def log_message(self, *args):  # quieter default logging
+        pass
+
+
+def main():
+    print(f"weasyprint-service listening on :{PORT}", flush=True)
+    ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds **server-side PDF rendering** to the preview app without putting the Python /
WeasyPrint stack into the app's hardened **Chainguard Node** image: a tiny Python
**WeasyPrint sidecar** runs as its own container, and the Express server proxies to
it via a new `/api/weasyprint` route.

One dumb, reusable contract everywhere: **POST `text/html` → `application/pdf`.**

## What's added

- **`weasyprint-service/`** — a stateless HTML→PDF service using WeasyPrint's
  **Python API** in-process (`server.py`, stdlib `http.server` — no Node, no
  subprocess). `Dockerfile` on a hardened **Chainguard (Wolfi) Python** base,
  `requirements.txt`, `README.md`. Internal-only (not publicly exposed).
- **`server/routes/weasyprint.js` + `server/index.js`** — `POST /api/weasyprint`
  parses the HTML body and proxies it to `WEASYPRINT_SERVICE_URL`, streaming back
  the PDF. This is the public, CORS-enabled surface (`app.use(cors())` already),
  so `preview.door43.org/api/weasyprint` is callable by:
  - this app, and
  - the door43-preview-renderers **styleguide** / library as its `pdfServiceUrl`.
- **`docker-compose.yml`** — internal `weasyprint` service (`expose`, not `ports`)
  + `WEASYPRINT_SERVICE_URL` and `depends_on` wired into `app`.

```
client ──POST /api/weasyprint (text/html)──► Express (this app, CORS) ──► weasyprint-service ──► PDF
```

## Why a sidecar (not in the app image)

The app image is `cgr.dev/chainguard/node` (minimal, no apt). WeasyPrint is a
Python tool with a native stack (Pango/cairo/…). Keeping it in its own
Chainguard **Python** container leaves the app image lean and hardened, and the
PDF engine stays a small, replaceable service.

## Verification

- The Python service renders a valid PDF from a `POST` (run under the WeasyPrint
  interpreter locally).
- Full path verified end to end: the Express route → service returns **200
  `application/pdf` (~6 KB)**.
- `docker-compose.yml` parses; route follows the existing `server/routes/*` style.

### ⚠️ Needs a real `docker build` before deploy
The Chainguard Dockerfile was authored without registry access — confirm the Wolfi
`apk` package names (`pango gdk-pixbuf fontconfig font-dejavu`, + any native dep
WeasyPrint reports) and that the `nonroot` user exists. Details + a distroless
multi-stage option are in `weasyprint-service/README.md`.

## Note
This branch deliberately excludes unrelated working-tree changes that were present
(`src/helpers/obs_helpers.js` and some stray files) — only the WeasyPrint files are
included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
