### PR TITLE
ci: push Docker images to Docker Hub (unfoldingword), not hub.door43.org

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -6,8 +6,9 @@ name: Build & push Docker images
 #   release published -> :stable, :<major>, :<major>.<minor>, :<major>.<minor>.<patch>
 #                        (semver taken from the release tag, e.g. v1.4.2)
 #
-# Images: door43-preview-app and door43-preview-weasyprint, on the same registry
-# and the same tags. Replaces Docker Hub's (retiring) autobuild service.
+# Images: docker.io/unfoldingword/door43-preview-app and
+# docker.io/unfoldingword/door43-preview-weasyprint — same tags. Replaces Docker
+# Hub's (retiring) autobuild service; still pushes to Docker Hub.
 on:
   push:
     branches: [develop, main]
@@ -16,9 +17,9 @@ on:
   workflow_dispatch:
 
 env:
-  # Registry to push to. The login uses the DOCKER_BUILD_USERNAME / DOCKER_BUILD_TOKEN
-  # repo secrets. Change REGISTRY if these images should live elsewhere.
-  REGISTRY: hub.door43.org
+  # Docker Hub org/namespace. Login uses the DOCKER_BUILD_USERNAME / DOCKER_BUILD_TOKEN
+  # repo secrets (a Docker Hub user + access token with push to this org).
+  NAMESPACE: unfoldingword
 
 jobs:
   build:
@@ -42,10 +43,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to ${{ env.REGISTRY }}
+      - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          # No `registry:` -> defaults to Docker Hub (docker.io).
           username: ${{ secrets.DOCKER_BUILD_USERNAME }}
           password: ${{ secrets.DOCKER_BUILD_TOKEN }}
 
@@ -53,7 +54,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ matrix.name }}
+          images: ${{ env.NAMESPACE }}/${{ matrix.name }}
           # Branch tags are gated by ref; the semver tags only apply on a release.
           tags: |
             type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}


### PR DESCRIPTION
The docker-images workflow failed on `docker/login-action` with `lookup hub.door43.org: no such host` — that registry doesn't exist (NXDOMAIN). All our images are on **Docker Hub**.

- `REGISTRY: hub.door43.org` → `NAMESPACE: unfoldingword`
- drop `registry:` from `docker/login-action` (defaults to Docker Hub / docker.io)
- images → `unfoldingword/door43-preview-app` and `unfoldingword/door43-preview-weasyprint`

Tag scheme unchanged (develop→:develop, main→:latest, release→:stable/semver). Uses the same `DOCKER_BUILD_USERNAME`/`DOCKER_BUILD_TOKEN` secrets — they must be a Docker Hub user + access token with push to the `unfoldingword` org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)