### PR TITLE
weasyprint: explicit upstream render timeout for large books

### DIFF
--- a/server/routes/weasyprint.js
+++ b/server/routes/weasyprint.js
@@ -8,6 +8,13 @@
 
 const SERVICE_URL = process.env.WEASYPRINT_SERVICE_URL || 'http://localhost:8080';
 
+// A full-book render (e.g. Romans TN) is synchronous and can take minutes.
+// Bound the upstream request explicitly: Node's global fetch (undici) defaults to
+// a ~300s headers timeout, which a 5-minute render sits right on the edge of. Give
+// a generous, configurable ceiling so long renders complete, while a genuinely
+// hung renderer still fails cleanly instead of hanging forever.
+const TIMEOUT_MS = Number(process.env.WEASYPRINT_TIMEOUT_MS) || 360000;
+
 export default async function weasyprint(req, res) {
   const html = typeof req.body === 'string' ? req.body : '';
   if (!html.trim()) {
@@ -21,6 +28,7 @@ export default async function weasyprint(req, res) {
       method: 'POST',
       headers: { 'Content-Type': 'text/html' },
       body: html,
+      signal: AbortSignal.timeout(TIMEOUT_MS),
     });
 
     if (!upstream.ok) {
@@ -36,8 +44,13 @@ export default async function weasyprint(req, res) {
     res.setHeader('Content-Length', pdf.length);
     res.end(pdf);
   } catch (e) {
+    const timedOut = e?.name === 'TimeoutError' || e?.name === 'AbortError';
     res
-      .status(502)
-      .json({ error: `weasyprint service unreachable at ${SERVICE_URL}: ${e.message}` });
+      .status(timedOut ? 504 : 502)
+      .json({
+        error: timedOut
+          ? `weasyprint service timed out after ${TIMEOUT_MS}ms rendering the PDF.`
+          : `weasyprint service unreachable at ${SERVICE_URL}: ${e.message}`,
+      });
   }
 }


### PR DESCRIPTION
## Why

Rendering a large book to PDF (e.g. **Romans TN**, ~56k lines of HTML) via `/api/weasyprint` was failing with a timeout. WeasyPrint renders the whole document synchronously, which legitimately takes **2–5 minutes** for big resources.

The Express proxy's upstream `fetch` to the Python sidecar had **no explicit timeout**, so it relied on Node 22's global `fetch` (undici) default headers timeout of ~300s — which a 5-minute render sits right on the edge of, causing intermittent failures.

## What

- Add `WEASYPRINT_TIMEOUT_MS` (default **360000ms / 6m**) and apply it via `AbortSignal.timeout()` on the app→sidecar fetch, so long renders complete while a genuinely hung renderer still fails cleanly.
- Return **504** with a clear "timed out" message when the ceiling is hit, instead of the generic 502 "unreachable".

## Companion change

The deploy side (puppet `preview-app.pp`) raises the nginx `/api` `proxy_read_timeout`/`proxy_send_timeout` from the 60s default to 360s and lifts `client_max_body_size` to 50m, so nginx no longer 504s mid-render. Both layers now comfortably exceed the 2–5m a big book takes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)